### PR TITLE
Added global config option to allow configuration of ssl settings

### DIFF
--- a/MongoRepository/GlobalConfig.cs
+++ b/MongoRepository/GlobalConfig.cs
@@ -1,0 +1,30 @@
+﻿using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MongoRepository
+{
+    public static class GlobalConfig
+    {
+        private static Action<SslSettings> ConfigureSslSettingsAction { get; set; }
+
+        public static void ConfigureSslSettings(Action<SslSettings> configureSslSettings)
+        {
+            ConfigureSslSettingsAction = configureSslSettings;
+        }
+
+        internal static SslSettings GetSslSettings(SslSettings settings)
+        {
+            if (settings == null)
+            {
+                settings = new SslSettings();
+            }
+
+            ConfigureSslSettingsAction?.Invoke(settings);
+
+            return settings;
+        }
+    }
+}

--- a/MongoRepository/MongoRepository.Net35.csproj
+++ b/MongoRepository/MongoRepository.Net35.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="CollectionName.cs" />
     <Compile Include="Entity.cs" />
+    <Compile Include="GlobalConfig.cs" />
     <Compile Include="IEntity.cs" />
     <Compile Include="RepositoryManager\IRepositoryManager.cs" />
     <Compile Include="RepositoryManager\MongoRepositoryManager.cs" />

--- a/MongoRepository/MongoRepository.Net40.csproj
+++ b/MongoRepository/MongoRepository.Net40.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="CollectionName.cs" />
     <Compile Include="Entity.cs" />
+    <Compile Include="GlobalConfig.cs" />
     <Compile Include="IEntity.cs" />
     <Compile Include="RepositoryManager\IRepositoryManager.cs" />
     <Compile Include="RepositoryManager\MongoRepositoryManager.cs" />

--- a/MongoRepository/MongoRepository.Net45.csproj
+++ b/MongoRepository/MongoRepository.Net45.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="CollectionName.cs" />
     <Compile Include="Entity.cs" />
+    <Compile Include="GlobalConfig.cs" />
     <Compile Include="IEntity.cs" />
     <Compile Include="RepositoryManager\IRepositoryManager.cs" />
     <Compile Include="RepositoryManager\MongoRepositoryManager.cs" />

--- a/MongoRepository/Util.cs
+++ b/MongoRepository/Util.cs
@@ -3,6 +3,7 @@
     using MongoDB.Driver;
     using System;
     using System.Configuration;
+    using System.Security.Authentication;
 
     /// <summary>
     /// Internal miscellaneous utility functions.
@@ -30,7 +31,10 @@
         /// <returns>Returns a MongoDatabase from the specified url.</returns>
         private static MongoDatabase GetDatabaseFromUrl(MongoUrl url)
         {
-            var client = new MongoClient(url);
+            var settings = MongoClientSettings.FromUrl(url);
+            settings.SslSettings = GlobalConfig.GetSslSettings(settings.SslSettings);
+
+            var client = new MongoClient(settings);
             var server = client.GetServer();
             return server.GetDatabase(url.DatabaseName); // WriteConcern defaulted to Acknowledged
         }


### PR DESCRIPTION
This PR allows you to use CosmosDB Mongo instance on azure which requires TLS1.2.

Usage:
`
MongoRepository.GlobalConfig.ConfigureSslSettings(x => x.EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12);
                    IRepository<NewsArticleDocument> repository = new MongoRepository<NewsArticleDocument>(ConfigurationManager.ConnectionStrings["MongoServerSettings"].ConnectionString, collectionName: "news-articles");
`